### PR TITLE
[FIX] 修复 macOS 26 导出时 Save Panel 默认文件名为空

### DIFF
--- a/ProfilesManager.xcodeproj/project.pbxproj
+++ b/ProfilesManager.xcodeproj/project.pbxproj
@@ -600,7 +600,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = ProfilesManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 11;
 				MARKETING_VERSION = 2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.skyfox.ProfilesManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -617,7 +617,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = ProfilesManager/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 11;
 				MARKETING_VERSION = 2.6;
 				PRODUCT_BUNDLE_IDENTIFIER = org.skyfox.ProfilesManager;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/ProfilesManager/Controller/ProfilesManagerViewController.m
+++ b/ProfilesManager/Controller/ProfilesManagerViewController.m
@@ -14,6 +14,7 @@
 #import "PreviewViewController.h"
 #import "PlistManager.h"
 #import "DateManager.h"
+#import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 //#include <unistd.h>
 //#include <sys/types.h>
 //#include <pwd.h>
@@ -499,9 +500,26 @@ static NSString *kColumnIdentifierCreateDays = @"days";
     ProfilesNode *node = [self.treeView itemAtRow:index];
     
     NSSavePanel *savePanel = [NSSavePanel savePanel];
-    savePanel.allowedFileTypes = @[@"mobileprovision", @"provisionprofile"];
-    savePanel.nameFieldStringValue = node.type ? : node.key;
+    NSMutableArray<UTType *> *types = [NSMutableArray array];
+    UTType *mobileprovisionType = [UTType typeWithFilenameExtension:@"mobileprovision"];
+    UTType *provisionprofileType = [UTType typeWithFilenameExtension:@"provisionprofile"];
+    if (mobileprovisionType) {
+        [types addObject:mobileprovisionType];
+    }
+    if (provisionprofileType) {
+        [types addObject:provisionprofileType];
+    }
+    if (types.count > 0) {
+        savePanel.allowedContentTypes = types;
+    }
     savePanel.extensionHidden = NO;
+    NSString *defaultName = node.type ? : node.key;
+    NSString *ext = node.filePath.pathExtension.length > 0 ? node.filePath.pathExtension : @"mobileprovision";
+    if (defaultName.length > 0 && ![defaultName hasSuffix:[@"." stringByAppendingString:ext]]) {
+        // Profile names often contain dots; avoid stringByAppendingPathExtension which mis-parses them.
+        defaultName = [NSString stringWithFormat:@"%@.%@", defaultName, ext];
+    }
+    savePanel.nameFieldStringValue = defaultName;
     
     [savePanel beginSheetModalForWindow:self.view.window completionHandler:^(NSInteger result) {
         NSString *savePath = savePanel.URL.path;


### PR DESCRIPTION
[FIX] 修复 macOS 26 导出时 Save Panel 默认文件名为空

改用 allowedContentTypes，并对含点号的 profile 名称用字符串拼接扩展名， 避免 stringByAppendingPathExtension: 误解析导致无法填充默认文件名。